### PR TITLE
Add redis sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,6 @@ It is important for us to enable a good developer experience although at this st
 complicated to completely decouple the projects. It is still likely that this will be happening in
 the next months, further help on this is highly appreciated
 
-##
+## Redis
+
+You'll need a redis running locally too.

--- a/foodsharing_api/session/__init__.py
+++ b/foodsharing_api/session/__init__.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+class SessionConfig(AppConfig):
+    name = 'foodsharing_api.session'
+
+    def ready(self):
+        from . import receivers

--- a/foodsharing_api/session/receivers.py
+++ b/foodsharing_api/session/receivers.py
@@ -1,0 +1,15 @@
+from django.contrib.auth.signals import user_logged_in, user_logged_out
+from django.dispatch import receiver
+from django.conf import settings
+from django_redis import get_redis_connection
+
+
+@receiver(user_logged_in)
+def add_session_to_user_session_map(sender, request, user, **kwargs):
+    redis = get_redis_connection(settings.SESSION_CACHE_ALIAS)
+    redis.sadd('api:user:{}:sessions'.format(user.id), request.session.session_key)
+
+@receiver(user_logged_out)
+def remove_session_from_user_session_map(sender, request, user, **kwargs):
+    redis = get_redis_connection(settings.SESSION_CACHE_ALIAS)
+    redis.srem('api:user:{}:sessions'.format(user.id), request.session.session_key)

--- a/foodsharing_api/settings.py
+++ b/foodsharing_api/settings.py
@@ -71,6 +71,25 @@ TEMPLATES = [
     },
 ]
 
+REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://{}:6379/0".format(REDIS_HOST),
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient"
+        }
+    }
+}
+
+SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+SESSION_CACHE_ALIAS = "default"
+
+# could probably be replaced with a small bit of middleware that calls redis
+# with EXPIRE to extend the TTL
+SESSION_SAVE_EVERY_REQUEST = True
+
 WSGI_APPLICATION = 'foodsharing_api.wsgi.application'
 
 

--- a/foodsharing_api/settings.py
+++ b/foodsharing_api/settings.py
@@ -31,7 +31,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'foodsharing_api.conversations.ConversationsConfig',
     'foodsharing_api.users',
-    'foodsharing_api.session',
+    'foodsharing_api.session.SessionConfig',
     'foodsharing_api.stores',
     'foodsharing_api.pickups',
     'foodsharing_api',
@@ -86,8 +86,7 @@ CACHES = {
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 SESSION_CACHE_ALIAS = "default"
 
-# could probably be replaced with a small bit of middleware that calls redis
-# with EXPIRE to extend the TTL
+# could probably be replaced with middleware that calls EXPIRE to extend the TTL
 SESSION_SAVE_EVERY_REQUEST = True
 
 WSGI_APPLICATION = 'foodsharing_api.wsgi.application'

--- a/requirements.in
+++ b/requirements.in
@@ -7,4 +7,6 @@ djangorestframework
 factory_boy
 mysqlclient
 flake8
-
+django-redis
+hiredis
+redis

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ coreapi==2.3.1            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 django-enumfields==0.9.0
 django-extensions==1.8.1
+django-redis==4.8.0
 django-rest-swagger==2.1.2
 django-silk==1.0.0
 django==1.11.3
@@ -18,6 +19,7 @@ djangorestframework==3.6.3
 factory-boy==2.8.1
 faker==0.7.17             # via factory-boy
 flake8==3.3.0
+hiredis==0.2.0
 idna==2.5                 # via requests
 itypes==1.1.0             # via coreapi
 jinja2==2.9.6             # via coreschema, django-silk
@@ -30,6 +32,7 @@ pyflakes==1.5.0           # via flake8
 pygments==2.2.0           # via django-silk
 python-dateutil==2.6.1    # via django-silk, faker
 pytz==2017.2              # via django, django-silk
+redis==2.10.5
 requests==2.18.1          # via coreapi, django-silk
 simplejson==3.11.1        # via django-rest-swagger
 six==1.10.0               # via django-extensions, faker, python-dateutil


### PR DESCRIPTION
This does two things:

1) configures the app to use redis for sessions
2) on login/logout adds/removes session ids to/from a redis set at key `api:user:<userid>:sessions`

As part of https://gitlab.com/foodsharing-dev/issues0/issues/219.