### PR TITLE
Update to use argon2 hashing

### DIFF
--- a/foodsharing_api/session/receivers.py
+++ b/foodsharing_api/session/receivers.py
@@ -8,17 +8,19 @@ from django_redis import get_redis_connection
 @receiver(user_logged_in)
 def add_session_to_user_session_map(sender, request, user, **kwargs):
     """Adding the session to redis"""
-    redis = get_redis_connection(settings.SESSION_CACHE_ALIAS)
-    redis.sadd(
-        'api:user:{}:sessions'.format(user.id),
-        request.session.session_key
-    )
+    if user:
+        redis = get_redis_connection(settings.SESSION_CACHE_ALIAS)
+        redis.sadd(
+            'api:user:{}:sessions'.format(user.id),
+            request.session.session_key
+        )
 
 @receiver(user_logged_out)
 def remove_session_from_user_session_map(sender, request, user, **kwargs):
     """Remove the session from redis"""
-    redis = get_redis_connection(settings.SESSION_CACHE_ALIAS)
-    redis.srem(
-        'api:user:{}:sessions'.format(user.id),
-        request.session.session_key
-    )
+    if user:
+        redis = get_redis_connection(settings.SESSION_CACHE_ALIAS)
+        redis.srem(
+            'api:user:{}:sessions'.format(user.id),
+            request.session.session_key
+        )

--- a/foodsharing_api/settings.py
+++ b/foodsharing_api/settings.py
@@ -116,6 +116,9 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.Argon2PasswordHasher',
+]
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/

--- a/foodsharing_api/users/models.py
+++ b/foodsharing_api/users/models.py
@@ -3,6 +3,7 @@ import hashlib
 
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.auth.base_user import BaseUserManager
+from django.contrib.auth.hashers import check_password
 from django.db import models
 
 
@@ -34,7 +35,7 @@ class User(models.Model):
     photo = models.CharField(max_length=50, blank=True, null=True)
     photo_public = models.IntegerField(default=0)
     email = models.CharField(unique=True, max_length=120, blank=True, null=True)
-    passwd = models.CharField(max_length=32, blank=True, null=True)
+    password = models.CharField(max_length=255, blank=True, null=True)
     first_name = models.CharField(
         max_length=120,
         blank=True,
@@ -143,21 +144,13 @@ class User(models.Model):
         managed = False
         db_table = 'fs_foodsaver'
 
-    def hash_password(self, raw_password):
-        """Calculates the hash for the raw password"""
-        salted_password = self.email.lower() + '-lz%&lk4-' + raw_password
-        hashed = hashlib.md5(salted_password.encode()).hexdigest()
-        return hashed
-
     def check_password(self, raw_password):
         """Checks if the password fits the hash"""
-        return self.passwd == self.hash_password(raw_password)
+        return check_password(raw_password, 'argon2{}'.format(self.password))
 
     def set_password(self, raw_password):
         """Sets a new password"""
-        if self.email:
-            self.passwd = self.hash_password(raw_password)
-            self.save()
+        raise Exception('unsupported')
 
     def __str__(self):
         """String representation of the User"""

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-django
+django[argon2]
 django-enumfields
 django-extensions
 django-rest-swagger

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,10 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+argon2-cffi==18.1.0       # via django
 autopep8==1.3.4           # via django-silk
 certifi==2018.1.18        # via requests
+cffi==1.11.5              # via argon2-cffi
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
@@ -14,7 +16,7 @@ django-extensions==2.0.6
 django-redis==4.9.0
 django-rest-swagger==2.1.2
 django-silk==2.0.0
-django==2.0.3
+django[argon2]==2.0.3
 djangorestframework==3.7.7
 factory-boy==2.10.0
 faker==0.8.12             # via factory-boy
@@ -23,12 +25,13 @@ gprof2dot==2016.10.13     # via django-silk
 hiredis==0.2.0
 idna==2.6                 # via requests
 itypes==1.1.0             # via coreapi
-jinja2==2.10              # via coreschema, django-silk
+jinja2==2.10              # via coreschema, django-silk, jinja2
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via flake8
 mysqlclient==1.3.12
 openapi-codec==1.3.2      # via django-rest-swagger
 pycodestyle==2.3.1        # via autopep8, flake8
+pycparser==2.18           # via cffi
 pyflakes==1.6.0           # via flake8
 pygments==2.2.0           # via django-silk
 python-dateutil==2.7.0    # via django-silk, faker
@@ -36,7 +39,7 @@ pytz==2018.3              # via django, django-silk
 redis==2.10.6
 requests==2.18.4          # via coreapi, django-silk
 simplejson==3.13.2        # via django-rest-swagger
-six==1.11.0               # via django-extensions, faker, python-dateutil
+six==1.11.0               # via argon2-cffi, django-extensions, faker, python-dateutil
 sqlparse==0.2.4           # via django-silk
 text-unidecode==1.2       # via faker
 uritemplate==3.0.0        # via coreapi

--- a/tests/users/test_user.py
+++ b/tests/users/test_user.py
@@ -40,9 +40,4 @@ class TestUser(TestCase):
     def test_password(self):
         """Testing password handling"""
         assert self.user.check_password(self.user.email)
-        hashed_pwd = self.user.hash_password(self.user.email)
-        assert hashed_pwd == self.user.passwd
-
-        self.user.set_password('new_password')
-        assert self.user.check_password('new_password')
 


### PR DESCRIPTION
As there is some interest in the foodsharing light project now, it seems worth at least making it so you can login and look around :)

This updates the check password code to use the same hash as the foodsharing backend itself uses.

I tried it locally on my docker-compose setup and was able to login. Currently you cannot login on the deployed site anyway (https://beta.light.foodsharing.de).